### PR TITLE
Fix the level count in Milgram Experiment scripts

### DIFF
--- a/scripts/simulate_milgram/simulate_milgram_experiment.py
+++ b/scripts/simulate_milgram/simulate_milgram_experiment.py
@@ -656,8 +656,9 @@ def run_single_experiment(
 
         # Update state.
         prompt_string = level_results["prompt_string"]
-        level += 1
         is_end_experiment = level_results["is_end_experiment"]
+        if not is_end_experiment:
+            level += 1
 
     # After experiment ends, save experiment overview.
     save_obj = {

--- a/scripts/simulate_milgram/simulate_milgram_experiment_alternate.py
+++ b/scripts/simulate_milgram/simulate_milgram_experiment_alternate.py
@@ -624,8 +624,9 @@ def run_single_experiment(
 
         # Update state.
         prompt_string = level_results["prompt_string"]
-        level += 1
         is_end_experiment = level_results["is_end_experiment"]
+        if not is_end_experiment:
+            level += 1
 
     # After experiment ends, save experiment overview.
     save_obj = {


### PR DESCRIPTION
Hey, I am working in a team from EPFL Data Science Lab that contacted you about the codebase. While adapting code for our needs and current OpenAI API I noticed the deviation between final logged level and the length of logged disobedience list -- and these 2 should match. 

![image](https://github.com/microsoft/turing-experiments/assets/62252332/b63dacfa-ccc7-46ed-abbb-2b4446d6906f)

I took a look at your Jupyter analysis and I think you accounted for this, but it still would be great to fix. This way if anyone else would like to use the code the logic will be correct and no one will overlook this error in their logs.  

This change only needs two small modifications in the while loop. 